### PR TITLE
Fix security issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ lib-cov
 
 # Coverage directory used by tools like istanbul
 coverage
+.nyc_output
 
 # Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
 .grunt
@@ -23,3 +24,5 @@ build/Release
 # Deployed apps should consider commenting this line out:
 # see https://npmjs.org/doc/faq.html#Should-I-check-my-node_modules-folder-into-git
 node_modules
+
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ koa-validate
 
 [![NPM](https://nodei.co/npm/koa-validate.png?downloads=true&downloadRank=true&stars=true)](https://nodei.co/npm/koa-validate/)
 
-validate koa request params and format request params 
+validate koa request params and format request params
 
 ## Installation
 ```
@@ -32,7 +32,7 @@ router.post('/signup', function * () {
 	this.checkBody('password').notEmpty().len(3, 20).md5();
 	//empty() mean this param can be a empty string.
 	this.checkBody('nick').optional().empty().len(3, 20);
-	//also we can get the sanitized value 
+	//also we can get the sanitized value
 	var age = this.checkBody('age').toInt().value;
 	yield this.checkFile('icon').notEmpty().size(0,300*1024,'file too large').move("/static/icon/" , function*(file,context){
 		//resize image
@@ -43,7 +43,7 @@ router.post('/signup', function * () {
 	}
 });
 router.get('/users', function * () {
-	this.checkQuery('department').empty().in(["sale","finance"], "not support this department!").len(3, 20);	
+	this.checkQuery('department').empty().in(["sale","finance"], "not support this department!").len(3, 20);
 	this.checkQuery('name').empty().len(2,20,"bad name.").trim().toLow();
 	this.checkQuery('age').empty().gt(10,"too young!").lt(30,"to old!").toInt();
 	if (this.errors) {
@@ -58,10 +58,10 @@ router.get('/user/:id', function * () {
 		return;
 	}
 });
-//json body,we can check it using [json path](https://github.com/flitbit/json-path)(like xpath)
+//json body,we can check it using [jsonpath-plus](https://github.com/JSONPath-Plus/JSONPath)
 router.post('/json' , function*(){
-	this.checkBody('/store/book[0]/price').get(0).eq(8.95);
-	this.checkBody('#/store/book[0]/category').first().trim().eq('reference');
+	this.checkBody("$.store.book[0].price").get(0).eq(8.95);
+	this.checkBody("$['store']['book'][0]['category']").first().trim().eq('reference');
 	if (this.errors) {
 		this.body = this.errors;
 		return;
@@ -168,14 +168,14 @@ when use `require('koa-validate')(app)` ,the request context will bind the metho
 - **ltrim([chars])** -  trim characters from the left-side of the param.
 - **rtrim([chars])** -  trim characters from the right-side of the param.
 - **escape()** -  replace <, >, & and " with HTML entities.
-- **stripLow()** -  remove characters with a numerical value < 32 and 127, mostly control characters. 
+- **stripLow()** -  remove characters with a numerical value < 32 and 127, mostly control characters.
 - **whitelist(value)** - remove characters that do not appear in the whitelist.
 - **blacklist(value)** - remove characters that appear in the blacklist.
 - **encodeURI()** - ref mdn [encodeURI](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI)
 - **decodeURI([tip])** - ref mdn [decodeURI](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/decodeURI)
 - **encodeURIComponent()** - ref mdn [encodeURIComponent](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent)
 - **decodeURIComponent([tip])** - ref mdn [decodeURIComponent](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/decodeURIComponent)
-- **replace(regexp|substr, newSubStr|function)** - the same as [String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace) replace 
+- **replace(regexp|substr, newSubStr|function)** - the same as [String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace) replace
 - **clone(newKey,[newValue])** - clone current value to the new key, if newValue supplied , use it. eg. `this.checkBody('v1').clone('md5').md5()`; then your can use `this.request.body.md5`.
 - **encodeBase64()** - encode current value to base64 string.
 - **decodeBase64([inBuffer],[tip])** - decode current base64 to a normal string,if inBuffer is true , the value will be a Buffer.

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "koa-validate",
-  "version": "1.0.7",
+  "version": "2.0.0",
   "description": "A koa params validate middleware.",
   "main": "validate.js",
   "scripts": {
-    "test": "NODE_ENV=test mocha --harmony --require should --reporter spec",
-    "test-cov": "NODE_ENV=test node --harmony ./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- --require should",
-    "test-travis": "NODE_ENV=test node --harmony ./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha --report lcovonly -- --require should"
+    "test": "NODE_ENV=test mocha --require should --reporter spec",
+    "test-cov": "nyc npm run test",
+    "test-cov-html": "npm run test-cov --reporter=html && open coverage/index.html"
   },
   "repository": {
     "type": "git",
@@ -33,6 +33,7 @@
     "koa-router": "^4",
     "mocha": "^10",
     "mocha-lcov-reporter": "*",
+    "nyc": "^15.1.0",
     "should": "*",
     "supertest": "^6.3.3"
   },

--- a/package.json
+++ b/package.json
@@ -23,19 +23,19 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "json-path": "^0.1.3",
+    "jsonpath-plus": "^7.2.0",
     "validator": "^5.2.0"
   },
   "devDependencies": {
-    "koa": "*",
-    "koa-router": "*",
-    "koa-body": "*",
-    "should": "*",
-    "mocha": "*",
-    "supertest": "^0.13.0",
     "coveralls": "*",
+    "istanbul-harmony": "0",
+    "koa": "*",
+    "koa-body": "^4",
+    "koa-router": "^4",
+    "mocha": "^10",
     "mocha-lcov-reporter": "*",
-    "istanbul-harmony": "0"
+    "should": "*",
+    "supertest": "^0.13.0"
   },
   "engines": {
     "node": ">= 0.11.9"

--- a/package.json
+++ b/package.json
@@ -24,11 +24,10 @@
   "license": "MIT",
   "dependencies": {
     "jsonpath-plus": "^7.2.0",
-    "validator": "^5.2.0"
+    "validator": "^13.9.0"
   },
   "devDependencies": {
     "coveralls": "*",
-    "istanbul-harmony": "0",
     "koa": "*",
     "koa-body": "^4",
     "koa-router": "^4",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "mocha": "^10",
     "mocha-lcov-reporter": "*",
     "should": "*",
-    "supertest": "^0.13.0"
+    "supertest": "^6.3.3"
   },
   "engines": {
     "node": ">= 0.11.9"

--- a/test/appFactory.js
+++ b/test/appFactory.js
@@ -3,7 +3,7 @@
 const koa = require('koa');
 
 exports.create = function(type) {
-	var app =	 new koa();
+	var app = new koa();
 	require('../validate.js')(app);
 	var router = require('koa-router')();
 	if(1 == type) {

--- a/test/appFactory.js
+++ b/test/appFactory.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var koa = require('koa');
+const koa = require('koa');
 
 exports.create = function(type) {
-	var app = koa();
+	var app =	 new koa();
 	require('../validate.js')(app);
 	var router = require('koa-router')();
 	if(1 == type) {
@@ -15,7 +15,7 @@ exports.create = function(type) {
 		try {
 			yield next;
 		}catch(err) {
-			console.log(err.stack)
+			console.error(err.stack)
 			this.app.emit('error', err, this);
 		}
 	})

--- a/test/test_checkFile.js
+++ b/test/test_checkFile.js
@@ -41,7 +41,7 @@ describe('koa-validate file uploads' , function(){
 		.attach('file',__dirname+"/test_checkFile.js")
 		.attach('file1',__dirname+"/test_checkFile.js")
 		// .attach('file2',__dirname+"/test_checkFile.js")
-		.send({type:"js"})
+		.field({type:"js"})
 		.expect(200)
 		.expect('ok' , done);
 	});
@@ -81,7 +81,7 @@ describe('koa-validate file uploads' , function(){
 		.attach('file5',__dirname+"/test_checkFile.js")
 		.attach('file5',__dirname+"/test_checkFile.js")
 		.attach('file6',__dirname+"/test_checkFile.js")
-		.send({type:"js"})
+		.field({type:"js"})
 		.expect(200)
 		.expect('ok' , done);
 	});

--- a/test/test_checkFile.js
+++ b/test/test_checkFile.js
@@ -7,7 +7,7 @@ require('should');
 
 
 
-describe('koa-validate' , function(){
+describe('koa-validate file uploads' , function(){
 	// this.timeout(100000);
 	it("file check ok" , function(done){
 		var app = appFactory.create(1);
@@ -26,8 +26,8 @@ describe('koa-validate' , function(){
 				return __dirname+"/temp";
 			})).delete();
 			require('fs').unlinkSync(__dirname+'/temp');
-			require('fs').unlinkSync(__dirname+'/'+require('path').basename(this.request.body.files.file.path));
-			require('fs').unlinkSync(__dirname+'/tempdir/'+require('path').basename(this.request.body.files.file.path));
+			require('fs').unlinkSync(__dirname+'/'+require('path').basename(this.request.files.file.path));
+			require('fs').unlinkSync(__dirname+'/tempdir/'+require('path').basename(this.request.files.file.path));
 			// require('fs').unlinkSync(__dirname+'/tempdir');
 			if(this.errors){
 				this.body = this.errors;
@@ -36,7 +36,7 @@ describe('koa-validate' , function(){
 			this.body = 'ok';
 		});
 
-		request(app.listen())
+		request(app.callback())
 		.post('/upload')
 		.attach('file',__dirname+"/test_checkFile.js")
 		.attach('file1',__dirname+"/test_checkFile.js")
@@ -70,7 +70,7 @@ describe('koa-validate' , function(){
 
 		});
 
-		request(app.listen())
+		request(app.callback())
 		.post('/upload')
 		.attach('file',__dirname+"/test_checkFile.js")
 		.attach('file0',__dirname+"/test_checkFile.js")

--- a/test/test_header.js
+++ b/test/test_header.js
@@ -5,7 +5,7 @@ request = require('supertest'),
 appFactory = require('./appFactory.js');
 require('should');
 
-describe('koa-validate' , function(){
+describe('koa-validate headers' , function(){
 	it("check header" , function(done){
 		var app = appFactory.create(1);
 		app.router.get('/header',function*(){
@@ -16,7 +16,7 @@ describe('koa-validate' , function(){
 				this.status=200;
 			}
 		});
-		request(app.listen())
+		request(app.callback())
 		.get('/header')
 		.set('int', "1")
 		.query().expect(200,done);

--- a/test/test_jsonPath.js
+++ b/test/test_jsonPath.js
@@ -81,6 +81,7 @@ describe('koa-validate type' , function(){
       this.checkBody('$.', true).notEmpty();
       this.checkBody('$.store.book[0].price', true).get(0).type('number').type('primitive');
       this.checkBody('$.store.book[0].price', true).get(0).type('hello'); // should warn
+      this.checkBody('$.store.book[0].price', true).exist();
       this.checkBody('$.store.book[0].category', true).first().type('string');
       this.checkBody('$.store.book[*].price', true).type('array');
       this.checkBody('$.store.book[0].publishDate', true).get(0).toDate().type('date').type('object');
@@ -96,7 +97,7 @@ describe('koa-validate type' , function(){
     .send(data)
     .expect(200 , done);
   });
-it("type fail check" , function(done){
+  it("type fail check" , function(done){
     const app = appFactory.create(1);
     app.router.post('/json',function*(){
       this.checkBody('$.', true).type('null');

--- a/test/test_jsonPath.js
+++ b/test/test_jsonPath.js
@@ -47,6 +47,7 @@ describe('koa-validate json path' , function(){
 		const app = appFactory.create(1);
 		app.router.post('/json',function*(){
       this.checkBody('$.store.bicycle.color', true).notEmpty();
+      this.checkBody('$.store.book[0].price', true).exist();
       this.checkBody('$.store.book[0].price', true).get(0).eq(8.95);
       this.checkBody('$.store.book[0].price', true).get(0).isFloat().eq(8.95);
       this.checkBody('$.store.book[0].disabled', true).first().notEmpty().toBoolean();
@@ -81,7 +82,6 @@ describe('koa-validate type' , function(){
       this.checkBody('$.', true).notEmpty();
       this.checkBody('$.store.book[0].price', true).get(0).type('number').type('primitive');
       this.checkBody('$.store.book[0].price', true).get(0).type('hello'); // should warn
-      this.checkBody('$.store.book[0].price', true).exist();
       this.checkBody('$.store.book[0].category', true).first().type('string');
       this.checkBody('$.store.book[*].price', true).type('array');
       this.checkBody('$.store.book[0].publishDate', true).get(0).toDate().type('date').type('object');
@@ -101,11 +101,12 @@ describe('koa-validate type' , function(){
     const app = appFactory.create(1);
     app.router.post('/json',function*(){
       this.checkBody('$.', true).type('null');
+      this.checkBody('$.store.cheeseburger', true).exist();
       this.checkBody('$.store.book[0].price', true).get(0).type('string');
       this.checkBody('$.store.book[0].category', true).first().type('null');
       this.checkBody('$.store.book[*].price', true).type('nullorundefined');
       this.checkBody('$.store.book[0].publishDate', true).first().toDate().type('array');
-      if(this.errors && 5==this.errors.length) {
+      if(this.errors && 6 == this.errors.length) {
         this.status=200;
       }else{
         this.status=500;

--- a/test/test_jsonPath.js
+++ b/test/test_jsonPath.js
@@ -8,7 +8,7 @@ var data = {
         title: "Sayings of the Century",
         price: 8.95,
         publishDate:"2015-01-01",
-        disabled:false
+        disabled: false
       },
       { category: "fiction",
         author: "Evelyn Waugh",
@@ -42,71 +42,75 @@ request = require('supertest'),
 appFactory = require('./appFactory.js');
 require('should');
 
-describe('koa-validate' , function(){
+describe('koa-validate json path' , function(){
 	it("json path basic" , function(done){
-		var app = appFactory.create(1);
+		const app = appFactory.create(1);
 		app.router.post('/json',function*(){
-			this.checkBody('/', true).notEmpty();
-      this.checkBody('/store/bicycle/color', true).exist()
-      this.checkBody('/store/book[0]/price', true).get(0).eq(8.95);
-      this.checkBody('/store/book[0]/price', true).get(0).isFloat().eq(8.95);
-			this.checkBody('/store/book[0]/disabled', true).first().notEmpty().toBoolean()
-			this.checkBody('#/store/book[0]/category', true).first().trim().eq('reference');
-			this.checkBody('/store/book[*]/price', true).filter(function(v,k,o){
-				return v>10
-			}).first().gt(10)
+      this.checkBody('$.store.bicycle.color', true).notEmpty();
+      this.checkBody('$.store.book[0].price', true).get(0).eq(8.95);
+      this.checkBody('$.store.book[0].price', true).get(0).isFloat().eq(8.95);
+      this.checkBody('$.store.book[0].disabled', true).first().notEmpty().toBoolean();
+      this.checkBody('$.store.book[0].category', true).first().trim().eq('reference');
+      this.checkBody('$.store.book[*].price', true).filter(function(v,k,o){
+        return v > 10;
+      }).first().gt(10);
+
 			if(this.errors) {
-        // console.log(this.errors)
 				this.status=500;
 			}else{
 				this.status=200;
 			}
 		});
-		var req = request(app.listen());
+		var req = request(app.callback());
 		req.post('/json')
 		.send(data)
-		.expect(200 , done);
+		.expect(200 , cb);
+    function cb(stuff){
+      console.log(stuff)
+       done()
+    }
 	});
 
 });
 
 describe('koa-validate type' , function(){
   it("type check" , function(done){
-    var app = appFactory.create(1);
+    const app = appFactory.create(1);
     app.router.post('/json',function*(){
-      this.checkBody('/', true).notEmpty();
-      this.checkBody('/store/book[0]/price', true).get(0).type('number').type("primitive")
-      this.checkBody('/store/book[0]/price', true).get(0).type('hello') // should warn
-      this.checkBody('#/store/book[0]/category', true).first().type('string');
-      this.checkBody('/store/book[*]/price', true).type('array')
-      this.checkBody('/store/book[0]/publishDate', true).get(0).toDate().type('date').type('object')
+
+      this.checkBody('$.', true).notEmpty();
+      this.checkBody('$.store.book[0].price', true).get(0).type('number').type('primitive');
+      this.checkBody('$.store.book[0].price', true).get(0).type('hello'); // should warn
+      this.checkBody('$.store.book[0].category', true).first().type('string');
+      this.checkBody('$.store.book[*].price', true).type('array');
+      this.checkBody('$.store.book[0].publishDate', true).get(0).toDate().type('date').type('object');
+
       if(this.errors) {
         this.status=500;
       }else{
         this.status=200;
       }
     });
-    var req = request(app.listen());
+    var req = request(app.callback());
     req.post('/json')
     .send(data)
     .expect(200 , done);
   });
 it("type fail check" , function(done){
-    var app = appFactory.create(1);
+    const app = appFactory.create(1);
     app.router.post('/json',function*(){
-      this.checkBody('/', true).type('null');
-      this.checkBody('/store/book[0]/price', true).get(0).type('string');
-      this.checkBody('#/store/book[0]/category', true).first().type('null');
-      this.checkBody('/store/book[*]/price', true).type('nullorundefined')
-      this.checkBody('/store/book[0]/publishDate', true).first().toDate().type('array')
-      // console.log(this.errors)
+      this.checkBody('$.', true).type('null');
+      this.checkBody('$.store.book[0].price', true).get(0).type('string');
+      this.checkBody('$.store.book[0].category', true).first().type('null');
+      this.checkBody('$.store.book[*].price', true).type('nullorundefined');
+      this.checkBody('$.store.book[0].publishDate', true).first().toDate().type('array');
       if(this.errors && 5==this.errors.length) {
         this.status=200;
       }else{
         this.status=500;
       }
     });
-    var req = request(app.listen());
+    const req = request(app.callback());
     req.post('/json')
     .send(data)
     .expect(200 , done);

--- a/test/test_nobody.js
+++ b/test/test_nobody.js
@@ -5,7 +5,7 @@ request = require('supertest'),
 appFactory = require('./appFactory.js');
 require('should');
 
-describe('koa-validate' , function(){
+describe('koa-validate nobody' , function(){
 	it("nobody to check" , function(done){
 		var app = appFactory.create(1);
 		app.router.post('/nobody',function*(){
@@ -16,7 +16,7 @@ describe('koa-validate' , function(){
 				this.status=200;
 			}
 		});
-		var req = request(app.listen());
+		var req = request(app.callback());
 		req.post('/nobody')
 		.send()
 		.expect(500 , done);

--- a/test/test_sanitizers_exceptions.js
+++ b/test/test_sanitizers_exceptions.js
@@ -7,7 +7,7 @@ require('should');
 
 
 
-describe('koa-validate' , function(){
+describe('koa-validate exception handling' , function(){
 	it("bad uri decodeURIComponent should not to be ok" , function(done){
 		var app = appFactory.create(1);
 		app.router.post('/decodeURIComponent',function*(){
@@ -18,7 +18,7 @@ describe('koa-validate' , function(){
 				this.status=200;
 			}
 		});
-		var req = request(app.listen());
+		var req = request(app.callback());
 		req.post('/decodeURIComponent')
 		.send({uri:"%"})
 		.expect(500 , done);
@@ -33,7 +33,7 @@ describe('koa-validate' , function(){
 				this.status=200;
 			}
 		});
-		var req = request(app.listen());
+		var req = request(app.callback());
 		req.post('/decodeURI')
 		.send({uri:"%"})
 		.expect(500 , done);
@@ -48,7 +48,7 @@ describe('koa-validate' , function(){
 				this.status=200;
 			}
 		});
-		var req = request(app.listen());
+		var req = request(app.callback());
 		req.post('/decodeBase64')
 		.send({base64:"%%"})
 		.expect(500 , done);
@@ -63,7 +63,7 @@ describe('koa-validate' , function(){
 				this.status=200;
 			}
 		});
-		var req = request(app.listen());
+		var req = request(app.callback());
 		req.post('/toInt')
 		.send({v:"gg"})
 		.expect(500 , done);
@@ -72,14 +72,14 @@ describe('koa-validate' , function(){
 	it("0 len should be ok" , function(done){
 		var app = appFactory.create(1);
 		app.router.post('/len',function*(){
-			this.checkBody('v').len(0,1);
+			this.checkBody('v').len(0,1, 'problem here');
 			if(this.errors) {
 				this.status=500;
 			}else{
 				this.status=200;
 			}
 		});
-		var req = request(app.listen());
+		var req = request(app.callback());
 		req.post('/len')
 		.send({v:""})
 		.expect(200 , done);

--- a/test/test_validate.js
+++ b/test/test_validate.js
@@ -6,7 +6,7 @@ appFactory = require('./appFactory.js');
 require('should');
 
 describe('koa-validate' , function(){
-	it("these validates should be to ok" , function(done){
+	it("returns OK when for all passing validators" , function(done){
 		var app = appFactory.create(1);
 		app.router.post('/validate',function*(){
 			this.checkBody('optional').optional().len(3,20);
@@ -79,6 +79,7 @@ describe('koa-validate' , function(){
 			this.checkBody('mac').isMACAddress();
 			this.checkBody('isin').isISIN();
 			this.checkBody('fqdn').isFQDN();
+			this.checkBody('exists').exist();
 			if(this.errors){
 				this.body = this.errors;
 				return;
@@ -148,12 +149,13 @@ describe('koa-validate' , function(){
 			mac:"C8:3A:35:CC:ED:80",
 			isin:"US0378331005",
 			fqdn:"www.google.com",
+			exists: "here",
 		})
 		.expect(200)
 		.expect('ok' ,done);
 	});
 
-	it("these validates fail tests should be to ok" , function(done){
+	it("returns errors for failing validators" , function(done){
 		var app = appFactory.create();
 		app.router.post('/validate',function*(ctx){
 			this.checkBody('name').notEmpty().len(3,20);
@@ -217,7 +219,8 @@ describe('koa-validate' , function(){
 			this.checkBody('isin').isISIN();
 			this.checkBody('fqdn').isFQDN();
 			this.checkBody('fqdn1').isFQDN();
-			if(this.errors.length === 61){
+			this.checkBody('exists').exist();
+			if(this.errors.length === 62){
 				this.body = 'ok';
 				return ;
 			}
@@ -285,7 +288,7 @@ describe('koa-validate' , function(){
 		.expect('ok' ,done);
 	});
 
-	it('there validate query should be to okay' , function(done){
+	it('validates query parameters' , function(done){
 		const app = appFactory.create();
 		app.router.get('/query',function*(){
 			this.checkQuery('name').notEmpty();
@@ -304,7 +307,7 @@ describe('koa-validate' , function(){
 		}).expect(200)
 		.expect('ok' , done);
 	});
-	it('there validate params should be to okay' , function(done){
+	it('validates url parameters' , function(done){
 		var app = appFactory.create();
 		app.router.get('/:id',function*(){
 			this.checkParams('id').isInt();

--- a/test/test_validate.js
+++ b/test/test_validate.js
@@ -88,7 +88,7 @@ describe('koa-validate' , function(){
 			}
 			this.body= 'ok';
 		});
-		var req = request(app.listen());
+		var req = request(app.callback());
 
 		req.post('/validate')
 		.send({
@@ -224,7 +224,7 @@ describe('koa-validate' , function(){
 			}
 			this.body= 'only '+this.errors.length+' errors';
 		});
-		var req = request(app.listen());
+		var req = request(app.callback());
 
 		req.post('/validate')
 		.send({
@@ -242,7 +242,7 @@ describe('koa-validate' , function(){
 			eq:"neq",
 			neq:'eq',
 			number4:'4',
-			contains:"hello" , 
+			contains:"hello" ,
 			notContains:"h f",
 			url:"google",
 			ip:'192.168.',
@@ -285,9 +285,9 @@ describe('koa-validate' , function(){
 		.expect(200)
 		.expect('ok' ,done);
 	});
-	
+
 	it('there validate query should be to okay' , function(done){
-		var app = appFactory.create();
+		const app = appFactory.create();
 		app.router.get('/query',function*(){
 			this.checkQuery('name').notEmpty();
 			this.checkQuery('password').len(3,20);
@@ -297,7 +297,7 @@ describe('koa-validate' , function(){
 			}
 			this.body = 'ok';
 		});
-		request(app.listen())
+		request(app.callback())
 		.get('/query')
 		.query({
 			name:'jim',
@@ -315,7 +315,7 @@ describe('koa-validate' , function(){
 			}
 			this.body = 'ok';
 		});
-		request(app.listen())
+		request(app.callback())
 		.get('/123')
 		.expect(200)
 		.expect('ok' , done);
@@ -358,7 +358,6 @@ describe('koa-validate' , function(){
 			this.checkBody('hash').clone('sha1').sha1();
 			this.checkBody('hash').clone('num1' ,1);
 			this.checkBody('json').toJson();
-			//console.log(this.request.body)
 			if(this.errors){
 				this.body = this.errors;
 				 return;
@@ -447,7 +446,7 @@ describe('koa-validate' , function(){
 			}
 			this.body = 'ok';
 		});
-		request(app.listen())
+		request(app.callback())
 		.post('/sanitizers')
 		.send({
 			int_:'20',

--- a/test/test_validate.js
+++ b/test/test_validate.js
@@ -54,7 +54,7 @@ describe('koa-validate' , function(){
 			this.checkBody('low').isLowercase();
 			this.checkBody('up').isUppercase();
 			this.checkBody('div').isDivisibleBy(3);
-			this.checkBody('n').isNull();
+			this.checkBody('n').isEmpty();
 			this.checkBody('len').isLength(1,4);
 			this.checkBody('byteLenght').isByteLength(4,6);
 			this.checkBody('uuid').isUUID();
@@ -190,7 +190,7 @@ describe('koa-validate' , function(){
 			this.checkBody('low').isLowercase();
 			this.checkBody('up').isUppercase();
 			this.checkBody('div').isDivisibleBy(3);
-			this.checkBody('n').isNull();
+			this.checkBody('n').isEmpty();
 			this.checkBody('len').isLength(3,4);
 			this.checkBody('len1').isLength(3,4);
 			this.checkBody('byteLength').isByteLength(4,6);

--- a/test/test_validate.js
+++ b/test/test_validate.js
@@ -81,7 +81,7 @@ describe('koa-validate' , function(){
 			this.checkBody('fqdn').isFQDN();
 			if(this.errors){
 				this.body = this.errors;
-				 return;
+				return;
 			}
 			if(8 !== this.request.body.age){
 				this.body= 'failed';
@@ -155,7 +155,7 @@ describe('koa-validate' , function(){
 
 	it("these validates fail tests should be to ok" , function(done){
 		var app = appFactory.create();
-		app.router.post('/validate',function*(){
+		app.router.post('/validate',function*(ctx){
 			this.checkBody('name').notEmpty().len(3,20);
 			this.checkBody('notEmpty').notEmpty();
 			this.checkBody('blank').notBlank();
@@ -168,7 +168,7 @@ describe('koa-validate' , function(){
 			this.checkBody('float_').isFloat();
 			this.checkBody('in').in([1,2]);
 			this.checkBody('eq').eq("eq");
-			this.checkBody('neq').neq("eq");
+			this.checkBody('notEqualTest').neq("equal");
 			this.checkBody('number4').gt(5);
 			this.checkBody('number4').lt(3);
 			this.checkBody('number4').ge(5);
@@ -218,7 +218,6 @@ describe('koa-validate' , function(){
 			this.checkBody('fqdn').isFQDN();
 			this.checkBody('fqdn1').isFQDN();
 			if(this.errors.length === 61){
-				this.body = this.errors;
 				this.body = 'ok';
 				return ;
 			}
@@ -239,8 +238,8 @@ describe('koa-validate' , function(){
 			integer2:"100",
 			float_:'a1.23',
 			in:'fd',
-			eq:"neq",
-			neq:'eq',
+			eq:"this does not equal eq",
+			notEqualTest:'equal',
 			number4:'4',
 			contains:"hello" ,
 			notContains:"h f",

--- a/validate.js
+++ b/validate.js
@@ -5,7 +5,7 @@ const path = require('path');
 const { JSONPath } = require('jsonpath-plus');
 
 function getValue(obj, key, transFn) {
-  if ((key.startsWith('$') || key.startsWith('#/')) && transFn) {
+  if (key.startsWith('$') && transFn) {
     let result = JSONPath({
       path: key,
       json: obj,
@@ -19,7 +19,7 @@ function getValue(obj, key, transFn) {
 }
 
 function hasKey(obj, key, transFn) {
-  if ((key.startsWith('/') || key.startsWith('#/')) && transFn) {
+  if (key.startsWith('/') && transFn) {
     let result = JSONPath({
       path: key,
       json: obj,

--- a/validate.js
+++ b/validate.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const { JSONPath } = require('jsonpath-plus');
 
-function getValue(obj, key, transFn) {
+const getValue = (obj, key, transFn) => {
   if (key.startsWith('$') && transFn) {
     let result = JSONPath({
       path: key,
@@ -12,139 +12,135 @@ function getValue(obj, key, transFn) {
       wrap: false,
       resultType: 'value'
     });
-		if (!Array.isArray(result)) result = [result];
-		return result;
+    if (!Array.isArray(result)) result = [result];
+    return result;
   }
   return obj[key]
 }
 
-function hasKey(obj, key, transFn) {
-  if (key.startsWith('/') && transFn) {
+const hasKey = (obj, key, transFn) => {
+  if (key.startsWith('$') && transFn) {
     let result = JSONPath({
       path: key,
       json: obj,
       wrap: false,
       resultType: 'all'
     });
-		if (!Array.isArray(result)) result = [result];
-		return result;
+    if (!Array.isArray(result)) result = [result];
+    return result.length > 0;
   }
   return key in obj;
 }
 
 module.exports = function(app) {
-	app.context.checkQuery = function(key,transFn) {
-		return new Validator(this, key, getValue(this.request.query,key,transFn), hasKey(this.request.query, key, transFn),this.request.query);
-	};
-	app.context.checkParams = function(key) {
-		return new Validator(this, key, this.params[key], key in this.params,this.params);
-	};
-	app.context.checkHeader = function(key) {
-		return new Validator(this, key, this.header[key], key in this.header,this.header);
-	};
-	app.context.checkBody = function(key,transFn) {
-		var body = this.request.body;
+  app.context.checkQuery = function(key,transFn) {
+    return new Validator(this, key, getValue(this.request.query,key,transFn), hasKey(this.request.query, key, transFn),this.request.query);
+  };
+  app.context.checkParams = function(key) {
+    return new Validator(this, key, this.params[key], key in this.params,this.params);
+  };
+  app.context.checkHeader = function(key) {
+    return new Validator(this, key, this.header[key], key in this.header,this.header);
+  };
+  app.context.checkBody = function(key,transFn) {
+    var body = this.request.body;
 
-		if(!body) {
-			if(!this.errors){
-				this.errors = ['no body to check!'];
-			}
-			return new Validator(this, null, null,false, null ,false );
-		}
-		var body =  body.fields || body;	// koa-body fileds. multipart fields in body.fields
-		return new Validator(this, key,getValue(body,key,transFn), hasKey(body, key, transFn), body);
-	};
-	app.context.checkFile = function(key , deleteOnCheckFailed) {
-		if('undefined' == typeof this.request.files ) {
-			if(!this.errors){
-				this.errors = ['no file to check'];
-			}
-			return new Validator(this, null, null,false, null,false );
-		}
-		deleteOnCheckFailed = ('undefined' == typeof deleteOnCheckFailed?true :false);
-		var files = this.request.files;
-		return new FileValidator(this, key ,files&&files[key],!!(files&&files[key]) , this.request.files , deleteOnCheckFailed);
-	};
-	// return function* (next) {
-	// 	yield next;
-	// };
-
+    if(!body) {
+      if(!this.errors){
+        this.errors = ['no body to check!'];
+      }
+      return new Validator(this, null, null,false, null ,false );
+    }
+    var body =  body.fields || body;	// koa-body fileds. multipart fields in body.fields
+    return new Validator(this, key,getValue(body,key,transFn), hasKey(body, key, transFn), body);
+  };
+  app.context.checkFile = function(key , deleteOnCheckFailed) {
+    if('undefined' == typeof this.request.files ) {
+      if(!this.errors){
+        this.errors = ['no file to check'];
+      }
+      return new Validator(this, null, null,false, null,false );
+    }
+    deleteOnCheckFailed = ('undefined' == typeof deleteOnCheckFailed?true :false);
+    var files = this.request.files;
+    return new FileValidator(this, key ,files&&files[key],!!(files&&files[key]) , this.request.files , deleteOnCheckFailed);
+  };
 };
 
 function isString(s) {
-	if(null == s)return false;
-	return 'string' == typeof(s)?true:false
+  if(null == s)return false;
+  return 'string' == typeof(s)?true:false
 }
 
 var v = require('validator');
 
 function Validator(context, key, value, exists, params , goOn) {
-	this.params = params;
-	this.context = context;
-	this.key = key;
-	this.value = value;
-	this.exists = exists;
-	this.goOn = (false===goOn?false:true);
-	if(this.value && this instanceof FileValidator && 'goOn' in this.value ){
-		this.goOn = this.value.goOn;
-	}
+  this.params = params;
+  this.context = context;
+  this.key = key;
+  this.value = value;
+  this.exists = exists;
+  this.goOn = (false===goOn?false:true);
+  if(this.value && this instanceof FileValidator && 'goOn' in this.value ){
+    this.goOn = this.value.goOn;
+  }
 }
 
 module.exports.Validator = Validator;
 //Validators
 Validator.prototype.addError = function(tip) {
-	this.goOn = false;
-	if(this.value && this instanceof FileValidator ){
-		this.value.goOn = false;
-	}
-	if (!this.context.errors) {
-		this.context.errors = [];
-	}
-	var e = {};
-	e[this.key] = tip;
-	this.context.errors.push(e);
+  this.goOn = false;
+  if(this.value && this instanceof FileValidator ){
+    this.value.goOn = false;
+  }
+  if (!this.context.errors) {
+    this.context.errors = [];
+  }
+  var e = {};
+  e[this.key] = tip;
+  this.context.errors.push(e);
 };
 
 Validator.prototype.hasError = function() {
-	return this.context.errors && this.context.errors.length > 0 ? true : false;
+  return this.context.errors && this.context.errors.length > 0 ? true : false;
 };
 Validator.prototype.optional = function() {
-	if (!this.exists) {
-		this.goOn = false;
-	}
-	return this;
+  if (!this.exists) {
+    this.goOn = false;
+  }
+  return this;
 };
 Validator.prototype.notEmpty = function(tip) {
-	if (this.goOn && (null==this.value||'undefined'==typeof(this.value) || ('string' == typeof(this.value) &&!this.value))) {
-		this.addError(tip || this.key + " can not be empty.");
-	}
-	return this;
+  if (this.goOn && (null==this.value||'undefined'==typeof(this.value) || ('string' == typeof(this.value) &&!this.value))) {
+    this.addError(tip || this.key + " can not be empty.");
+  }
+  return this;
 };
 Validator.prototype.empty = function() {
-	if (this.goOn) {
-		if (!this.value) {
-			this.goOn = false;
-		}
-	}
-	return this;
+  if (this.goOn) {
+    if (!this.value) {
+      this.goOn = false;
+    }
+  }
+  return this;
 };
 Validator.prototype.notBlank = function(tip) {
-	if (this.goOn && (null==this.value||'undefined'==typeof(this.value) || ('string' == typeof(this.value) &&(/^\s*$/gi).test(this.value)))) {
-		this.addError(tip || this.key + " can not be blank.");
-	}
-	return this;
+  if (this.goOn && (null==this.value||'undefined'==typeof(this.value) || ('string' == typeof(this.value) &&(/^\s*$/gi).test(this.value)))) {
+    this.addError(tip || this.key + " can not be blank.");
+  }
+  return this;
 };
 Validator.prototype.exist = function(tip) {
-	if (this.goOn && !this.exists) {
-		 this.addError(tip || this.key +" should exist!");
-	}
-	return this;
+  if (this.goOn && !this.exists) {
+     this.addError(tip || this.key +" should exist!");
+  }
+  return this;
 };
 Validator.prototype.match = function(reg, tip) {
-	if (this.goOn && !reg.test(this.value)) {
-		this.addError(tip || this.key + " is bad format.");
-	}
-	return this;
+  if (this.goOn && !reg.test(this.value)) {
+    this.addError(tip || this.key + " is bad format.");
+  }
+  return this;
 };
 
 /**
@@ -175,631 +171,630 @@ Validator.prototype.ensure = function(assertion, tip, shouldBail) {
 };
 
 Validator.prototype.isInt = function(tip, options) {
-	if (this.goOn&& !v.isInt(String(this.value), options)) {
-		this.addError(tip || this.key + " is not integer.");
-	}
-	return this;
+  if (this.goOn&& !v.isInt(String(this.value), options)) {
+    this.addError(tip || this.key + " is not integer.");
+  }
+  return this;
 };
 Validator.prototype.isFloat = function(tip,options) {
-	if (this.goOn && !v.isFloat(String(this.value), options)) {
-		this.addError(tip || this.key + " is not float.");
-	}
-	return this;
+  if (this.goOn && !v.isFloat(String(this.value), options)) {
+    this.addError(tip || this.key + " is not float.");
+  }
+  return this;
 };
 
 Validator.prototype.isLength = function(min, max, tip) {
-	min = min || 0;
-	tip = 'number' != typeof max ? max : tip;
-	max = 'number' == typeof max ? max :-1;
-	this.exist(tip);
-	if (this.goOn) {
-		if(this.value.length<min) {
-			this.addError(tip || this.key + "'s length must equal or great than " + min+".");
-			return this;
-		}
-		if (-1!=max&&this.value.length>max) {
-			this.addError(tip || this.key + "'s length must equal or less than " + max + ".");
-			return this;
-		}
-	}
-	return this;
+  min = min || 0;
+  tip = 'number' != typeof max ? max : tip;
+  max = 'number' == typeof max ? max :-1;
+  this.exist(tip);
+  if (this.goOn) {
+    if(this.value.length<min) {
+      this.addError(tip || this.key + "'s length must equal or great than " + min+".");
+      return this;
+    }
+    if (-1!=max&&this.value.length>max) {
+      this.addError(tip || this.key + "'s length must equal or less than " + max + ".");
+      return this;
+    }
+  }
+  return this;
 };
 Validator.prototype.len = Validator.prototype.isLength;
 Validator.prototype.in = function(arr, tip) {
-	if (this.goOn && arr) {
-		for(var i = 0 ; i < arr.length ;i++){
-			if(this.value == arr[i]){
-				return this;
-			}
-		}
-		this.addError(tip || this.key + " must be in [" + arr.join(',') + "].");
-	}
-	return this;
+  if (this.goOn && arr) {
+    for(var i = 0 ; i < arr.length ;i++){
+      if(this.value == arr[i]){
+        return this;
+      }
+    }
+    this.addError(tip || this.key + " must be in [" + arr.join(',') + "].");
+  }
+  return this;
 };
 Validator.prototype.isIn = Validator.prototype.in;
 Validator.prototype.eq = function(l, tip) {
-	if (this.goOn && this.value != l) {
-		this.addError(tip || this.key + " must equal " + l + ".");
-	}
-	return this;
+  if (this.goOn && this.value != l) {
+    this.addError(tip || this.key + " must equal " + l + ".");
+  }
+  return this;
 };
 Validator.prototype.neq = function(l, tip) {
-	if (this.goOn && this.value == l) {
-		console.log('adding the error!')
-		this.addError(tip || this.key + " must not equal " + l + ".");
-	}
-	return this;
+  if (this.goOn && this.value == l) {
+    this.addError(tip || this.key + " must not equal " + l + ".");
+  }
+  return this;
 };
 Validator.prototype.gt = function(l, tip) {
-	if (this.goOn && this.value <= l) {
-		this.addError(tip || this.key + " must great than " + l + ".");
-	}
-	return this;
+  if (this.goOn && this.value <= l) {
+    this.addError(tip || this.key + " must great than " + l + ".");
+  }
+  return this;
 };
 Validator.prototype.lt = function(l, tip) {
-	if (this.goOn && this.value >= l) {
-		this.addError(tip || this.key + " must less than " + l + ".");
-	}
-	return this;
+  if (this.goOn && this.value >= l) {
+    this.addError(tip || this.key + " must less than " + l + ".");
+  }
+  return this;
 };
 Validator.prototype.ge = function(l, tip) {
-	if (this.goOn && this.value < l) {
-		this.addError(tip || this.key + " must great than or equal " + l + ".");
-	}
-	return this;
+  if (this.goOn && this.value < l) {
+    this.addError(tip || this.key + " must great than or equal " + l + ".");
+  }
+  return this;
 };
 Validator.prototype.le = function(l, tip) {
-	if (this.goOn && this.value > l) {
-		this.addError(tip || this.key + " must less than or equal " + l + ".");
-	}
-	return this;
+  if (this.goOn && this.value > l) {
+    this.addError(tip || this.key + " must less than or equal " + l + ".");
+  }
+  return this;
 };
 Validator.prototype.contains = function(s, tip) {
-	if (this.goOn && (!isString(this.value) ||!v.contains(this.value,s))) {
-		this.addError(tip || this.key + " must contain " + s + ".");
-	}
-	return this;
+  if (this.goOn && (!isString(this.value) ||!v.contains(this.value,s))) {
+    this.addError(tip || this.key + " must contain " + s + ".");
+  }
+  return this;
 };
 Validator.prototype.notContains = function(s, tip) {
-	if (this.goOn && (!isString(this.value) ||v.contains(this.value,s))) {
-		this.addError(tip || this.key + " must not contain " + s + ".");
-	}
-	return this;
+  if (this.goOn && (!isString(this.value) ||v.contains(this.value,s))) {
+    this.addError(tip || this.key + " must not contain " + s + ".");
+  }
+  return this;
 };
 Validator.prototype.isEmail = function(tip,options) {
-	if (this.goOn && (!isString(this.value) ||!v.isEmail(this.value,options))) {
-		this.addError(tip || this.key + " is not email format.");
-	}
-	return this;
+  if (this.goOn && (!isString(this.value) ||!v.isEmail(this.value,options))) {
+    this.addError(tip || this.key + " is not email format.");
+  }
+  return this;
 };
 Validator.prototype.isUrl = function(tip,options) {
-	if (this.goOn && (!isString(this.value) ||!v.isURL(this.value,options))) {
-		this.addError(tip || this.key + " is not url format.");
-	}
-	return this;
+  if (this.goOn && (!isString(this.value) ||!v.isURL(this.value,options))) {
+    this.addError(tip || this.key + " is not url format.");
+  }
+  return this;
 };
 Validator.prototype.isIp = function(tip,version) {
-	if (this.goOn && (!isString(this.value) ||!v.isIP(this.value,version))) {
-		this.addError(tip || this.key + " is not ip format.");
-	}
-	return this;
+  if (this.goOn && (!isString(this.value) ||!v.isIP(this.value,version))) {
+    this.addError(tip || this.key + " is not ip format.");
+  }
+  return this;
 };
 Validator.prototype.isAlpha = function(tip,locale) {
-	if (this.goOn && (!isString(this.value) ||!v.isAlpha(this.value,locale))) {
-		this.addError(tip || this.key + " is not an alpha string.");
-	}
-	return this;
+  if (this.goOn && (!isString(this.value) ||!v.isAlpha(this.value,locale))) {
+    this.addError(tip || this.key + " is not an alpha string.");
+  }
+  return this;
 };
 Validator.prototype.isNumeric = function(tip) {
-	if (this.goOn && (!isString(this.value) ||!v.isNumeric(this.value))) {
-		this.addError(tip || this.key + " is  not numeric.");
-	}
-	return this;
+  if (this.goOn && (!isString(this.value) ||!v.isNumeric(this.value))) {
+    this.addError(tip || this.key + " is  not numeric.");
+  }
+  return this;
 };
 
 Validator.prototype.isAlphanumeric = function(tip,locale) {
-	if (this.goOn && (!isString(this.value) ||!v.isAlphanumeric(this.value,locale))) {
-		this.addError(tip || this.key + " is not an aphanumeric string.");
-	}
-	return this;
+  if (this.goOn && (!isString(this.value) ||!v.isAlphanumeric(this.value,locale))) {
+    this.addError(tip || this.key + " is not an aphanumeric string.");
+  }
+  return this;
 };
 Validator.prototype.isBase64 = function(tip) {
-	if (this.goOn && (!isString(this.value) ||!v.isBase64(this.value))) {
-		this.addError(tip || this.key + " is not a base64 string.");
-	}
-	return this;
+  if (this.goOn && (!isString(this.value) ||!v.isBase64(this.value))) {
+    this.addError(tip || this.key + " is not a base64 string.");
+  }
+  return this;
 };
 Validator.prototype.isHexadecimal = function(tip) {
-	if (this.goOn && (!isString(this.value) ||!v.isHexadecimal(this.value))) {
-		this.addError(tip || this.key + " is not a hexa decimal string.");
-	}
-	return this;
+  if (this.goOn && (!isString(this.value) ||!v.isHexadecimal(this.value))) {
+    this.addError(tip || this.key + " is not a hexa decimal string.");
+  }
+  return this;
 };
 Validator.prototype.isHexColor = function(tip) {
-	if (this.goOn && (!isString(this.value) ||!v.isHexColor(this.value))) {
-		this.addError(tip || this.key + " is  not hex color format.");
-	}
-	return this;
+  if (this.goOn && (!isString(this.value) ||!v.isHexColor(this.value))) {
+    this.addError(tip || this.key + " is  not hex color format.");
+  }
+  return this;
 };
 Validator.prototype.isLowercase = function(tip) {
-	if (this.goOn && (!isString(this.value) ||!v.isLowercase(this.value))) {
-		this.addError(tip || this.key + " is not a lowwer case string");
-	}
-	return this;
+  if (this.goOn && (!isString(this.value) ||!v.isLowercase(this.value))) {
+    this.addError(tip || this.key + " is not a lowwer case string");
+  }
+  return this;
 };
 Validator.prototype.isUppercase = function(tip) {
-	if (this.goOn && (!isString(this.value) ||!v.isUppercase(this.value))) {
-		this.addError(tip || this.key + " is not a upper case string.");
-	}
-	return this;
+  if (this.goOn && (!isString(this.value) ||!v.isUppercase(this.value))) {
+    this.addError(tip || this.key + " is not a upper case string.");
+  }
+  return this;
 };
 Validator.prototype.isDivisibleBy = function(n, tip) {
-	if (this.goOn && (!isString(this.value) ||!v.isDivisibleBy(this.value, n))) {
-		this.addError(tip || this.key + " can not divide by" + n + ".");
-	}
-	return this;
+  if (this.goOn && (!isString(this.value) ||!v.isDivisibleBy(this.value, n))) {
+    this.addError(tip || this.key + " can not divide by" + n + ".");
+  }
+  return this;
 };
 Validator.prototype.isEmpty = function(tip) {
-	if (this.goOn && (!isString(this.value) ||!v.isEmpty(this.value))) {
-		this.addError(tip || this.key + " is not empty.");
-	}
-	return this;
+  if (this.goOn && (!isString(this.value) ||!v.isEmpty(this.value))) {
+    this.addError(tip || this.key + " is not empty.");
+  }
+  return this;
 };
 Validator.prototype.isByteLength = function(min, max,charset,tip) {
-	min = min || 0;
-	max = max || Number.MAX_VALUE;
-	charset = charset||'utf8';
-	this.notEmpty(tip);
-	if (this.goOn) {
-		var bl = Buffer.byteLength(this.value , charset);
-		tip = 'number' != typeof max ? max : tip;
-		if (bl<min || bl>max) {
-			this.addError(tip || this.key + "'s byte lenth great than " + min +" and less than " + max + "." );
-		}
-	}
-	return this;
+  min = min || 0;
+  max = max || Number.MAX_VALUE;
+  charset = charset||'utf8';
+  this.notEmpty(tip);
+  if (this.goOn) {
+    var bl = Buffer.byteLength(this.value , charset);
+    tip = 'number' != typeof max ? max : tip;
+    if (bl<min || bl>max) {
+      this.addError(tip || this.key + "'s byte lenth great than " + min +" and less than " + max + "." );
+    }
+  }
+  return this;
 };
 Validator.prototype.byteLength = Validator.prototype.isByteLength;
 Validator.prototype.isUUID = function(tip,ver) {
-	if (this.goOn && (!isString(this.value) ||!v.isUUID(this.value,ver))) {
-		this.addError(tip || this.key + " is not a UUID format.");
-	}
-	return this;
+  if (this.goOn && (!isString(this.value) ||!v.isUUID(this.value,ver))) {
+    this.addError(tip || this.key + " is not a UUID format.");
+  }
+  return this;
 };
 Validator.prototype.isDate = function(tip) {
-	if (this.goOn && !util.isDate(this.value)  && (!isString(this.value) ||!v.isDate(this.value))) {
-		this.addError(tip || this.key + " is not a date format.");
-	}
-	return this;
+  if (this.goOn && !util.isDate(this.value)  && (!isString(this.value) ||!v.isDate(this.value))) {
+    this.addError(tip || this.key + " is not a date format.");
+  }
+  return this;
 };
 Validator.prototype.isTime = function(tip) {
-	var timeReg = /^(([0-1]?[0-9])|([2][0-3])):([0-5]?[0-9])(:([0-5]?[0-9]))?$/;
-	if(this.goOn && ! timeReg.test(this.value)){
-		this.addError(tip || this.key + " is not a time format.");
-	}
-	return this;
+  var timeReg = /^(([0-1]?[0-9])|([2][0-3])):([0-5]?[0-9])(:([0-5]?[0-9]))?$/;
+  if(this.goOn && ! timeReg.test(this.value)){
+    this.addError(tip || this.key + " is not a time format.");
+  }
+  return this;
 };
 
 Validator.prototype.isAfter = function(d, tip) {
-	if (this.goOn && (!isString(this.value) ||!v.isAfter(this.value, d))) {
-		this.addError(tip || this.key + " must after " + d + ".");
-	}
-	return this;
+  if (this.goOn && (!isString(this.value) ||!v.isAfter(this.value, d))) {
+    this.addError(tip || this.key + " must after " + d + ".");
+  }
+  return this;
 };
 Validator.prototype.isBefore = function(d, tip) {
-	if (this.goOn && (!isString(this.value) ||!v.isBefore(this.value, d))) {
-		this.addError(tip || this.key + " must before " + d + ".");
-	}
-	return this;
+  if (this.goOn && (!isString(this.value) ||!v.isBefore(this.value, d))) {
+    this.addError(tip || this.key + " must before " + d + ".");
+  }
+  return this;
 };
 Validator.prototype.isCreditCard = function(tip) {
-	if (this.goOn && (!isString(this.value) ||!v.isCreditCard(this.value))) {
-		this.addError(tip || this.key + " is not credit card format.");
-	}
-	return this;
+  if (this.goOn && (!isString(this.value) ||!v.isCreditCard(this.value))) {
+    this.addError(tip || this.key + " is not credit card format.");
+  }
+  return this;
 };
 Validator.prototype.isISBN = function(tip,version) {
-	if (this.goOn && (!isString(this.value) ||!v.isISBN(this.value,version))) {
-		this.addError(tip || this.key + " is not a ISBN format.");
-	}
-	return this;
+  if (this.goOn && (!isString(this.value) ||!v.isISBN(this.value,version))) {
+    this.addError(tip || this.key + " is not a ISBN format.");
+  }
+  return this;
 };
 Validator.prototype.isJSON = function(tip) {
-	if (this.goOn && (!isString(this.value) ||!v.isJSON(this.value))) {
-		this.addError(tip || this.key + " is not a json format.");
-	}
-	return this;
+  if (this.goOn && (!isString(this.value) ||!v.isJSON(this.value))) {
+    this.addError(tip || this.key + " is not a json format.");
+  }
+  return this;
 };
 
 Validator.prototype.isMultibyte = function(tip) {
-	if (this.goOn && (!isString(this.value) ||!v.isMultibyte(this.value))) {
-		this.addError(tip || this.key + " is not a multibyte string.");
-	}
-	return this;
+  if (this.goOn && (!isString(this.value) ||!v.isMultibyte(this.value))) {
+    this.addError(tip || this.key + " is not a multibyte string.");
+  }
+  return this;
 };
 Validator.prototype.isAscii = function(tip) {
-	if (this.goOn && (!isString(this.value) ||!v.isAscii(this.value))) {
-		this.addError(tip || this.key + " is not a ascii string.");
-	}
-	return this;
+  if (this.goOn && (!isString(this.value) ||!v.isAscii(this.value))) {
+    this.addError(tip || this.key + " is not a ascii string.");
+  }
+  return this;
 };
 Validator.prototype.isFullWidth = function(tip) {
-	if (this.goOn && (!isString(this.value) ||!v.isFullWidth(this.value))) {
-		this.addError(tip || this.key + " is not a full width string.");
-	}
-	return this;
+  if (this.goOn && (!isString(this.value) ||!v.isFullWidth(this.value))) {
+    this.addError(tip || this.key + " is not a full width string.");
+  }
+  return this;
 };
 Validator.prototype.isHalfWidth = function(tip) {
-	if (this.goOn && (!isString(this.value) ||!v.isHalfWidth(this.value))) {
-		this.addError(tip || this.key + " is not a half width string.");
-	}
-	return this;
+  if (this.goOn && (!isString(this.value) ||!v.isHalfWidth(this.value))) {
+    this.addError(tip || this.key + " is not a half width string.");
+  }
+  return this;
 };
 Validator.prototype.isVariableWidth = function(tip) {
-	if (this.goOn && (!isString(this.value) ||!v.isVariableWidth(this.value))) {
-		this.addError(tip || this.key + " is not a variable width string.");
-	}
-	return this;
+  if (this.goOn && (!isString(this.value) ||!v.isVariableWidth(this.value))) {
+    this.addError(tip || this.key + " is not a variable width string.");
+  }
+  return this;
 };
 Validator.prototype.isSurrogatePair = function(tip) {
-	if (this.goOn && (!isString(this.value) ||!v.isSurrogatePair(this.value))) {
-		this.addError(tip || this.key + " is not a surrogate pair string.");
-	}
-	return this;
+  if (this.goOn && (!isString(this.value) ||!v.isSurrogatePair(this.value))) {
+    this.addError(tip || this.key + " is not a surrogate pair string.");
+  }
+  return this;
 };
 Validator.prototype.isCurrency = function(tip,options) {
-	if (this.goOn && (!isString(this.value) ||!v.isCurrency(this.value,options))) {
-		this.addError(tip || this.key + " is not a currency format.");
-	}
-	return this;
+  if (this.goOn && (!isString(this.value) ||!v.isCurrency(this.value,options))) {
+    this.addError(tip || this.key + " is not a currency format.");
+  }
+  return this;
 };
 Validator.prototype.isDataURI = function(tip) {
-	if (this.goOn && (!isString(this.value) ||!v.isDataURI(this.value))) {
-		this.addError(tip || this.key + " is not a data uri format.");
-	}
-	return this;
+  if (this.goOn && (!isString(this.value) ||!v.isDataURI(this.value))) {
+    this.addError(tip || this.key + " is not a data uri format.");
+  }
+  return this;
 };
 Validator.prototype.isMobilePhone = function(tip,locale) {
-	if (this.goOn && (!isString(this.value) ||!v.isMobilePhone(this.value,locale))) {
-		this.addError(tip || this.key + " is not a mobile phone format.");
-	}
-	return this;
+  if (this.goOn && (!isString(this.value) ||!v.isMobilePhone(this.value,locale))) {
+    this.addError(tip || this.key + " is not a mobile phone format.");
+  }
+  return this;
 };
 Validator.prototype.isISO8601 = function(tip) {
-	if (this.goOn && (!isString(this.value) ||!v.isISO8601(this.value))) {
-		this.addError(tip || this.key + " is not a ISO8601 string format.");
-	}
-	return this;
+  if (this.goOn && (!isString(this.value) ||!v.isISO8601(this.value))) {
+    this.addError(tip || this.key + " is not a ISO8601 string format.");
+  }
+  return this;
 };
 Validator.prototype.isMACAddress = function(tip) {
-	if (this.goOn && (!isString(this.value) ||!v.isMACAddress(this.value))) {
-		this.addError(tip || this.key + " is not a MAC address format.");
-	}
-	return this;
+  if (this.goOn && (!isString(this.value) ||!v.isMACAddress(this.value))) {
+    this.addError(tip || this.key + " is not a MAC address format.");
+  }
+  return this;
 };
 
 Validator.prototype.isISIN = function(tip) {
-	if (this.goOn && (!isString(this.value) ||!v.isISIN(this.value))) {
-		this.addError(tip || this.key + " is not a ISIN format.");
-	}
-	return this;
+  if (this.goOn && (!isString(this.value) ||!v.isISIN(this.value))) {
+    this.addError(tip || this.key + " is not a ISIN format.");
+  }
+  return this;
 };
 Validator.prototype.isFQDN = function(tip,options) {
-	if (this.goOn && (!isString(this.value) ||!v.isFQDN(this.value,options))) {
-		this.addError(tip || this.key + " is not a fully qualified domain name format.");
-	}
-	return this;
+  if (this.goOn && (!isString(this.value) ||!v.isFQDN(this.value,options))) {
+    this.addError(tip || this.key + " is not a fully qualified domain name format.");
+  }
+  return this;
 };
 
 
 //Sanitizers
 Validator.prototype.default = function(d) {
-	if(!this.hasError()&&!this.value){
-		this.value = this.params[this.key] = d;
-	}
-	return this;
+  if(!this.hasError()&&!this.value){
+    this.value = this.params[this.key] = d;
+  }
+  return this;
 };
 Validator.prototype.toDate = function() {
-	this.isDate();
-	if (this.goOn && !this.hasError()) {
-		this.value = this.params[this.key] = v.toDate(this.value);
-	}
-	return this;
+  this.isDate();
+  if (this.goOn && !this.hasError()) {
+    this.value = this.params[this.key] = v.toDate(this.value);
+  }
+  return this;
 };
 Validator.prototype.toInt = function(tip, radix, options) {
-	this.isInt(tip, options);
-	if (this.goOn && !this.hasError()) {
-		if('number' == typeof(this.value)) {
-			return this;
-		}
-		this.value = this.params[this.key] = v.toInt(this.value, radix);
-	}
-	return this;
+  this.isInt(tip, options);
+  if (this.goOn && !this.hasError()) {
+    if('number' == typeof(this.value)) {
+      return this;
+    }
+    this.value = this.params[this.key] = v.toInt(this.value, radix);
+  }
+  return this;
 };
 Validator.prototype.toFloat = function(tip) {
-	this.isFloat(tip);
-	if (this.goOn && !this.hasError()) {
-		if('number' == typeof(this.value)) {
-			return this;
-		}
-		this.value = this.params[this.key] = v.toFloat(this.value);
-	}
-	return this;
+  this.isFloat(tip);
+  if (this.goOn && !this.hasError()) {
+    if('number' == typeof(this.value)) {
+      return this;
+    }
+    this.value = this.params[this.key] = v.toFloat(this.value);
+  }
+  return this;
 };
 Validator.prototype.toJson = function(tip) {
-	if (this.goOn && !this.hasError()) {
-		try{
-			if('object' == typeof(this.value)) {
-				return this;
-			}
-			this.value = this.params[this.key] = JSON.parse(this.value);
-		}catch(e){
-			this.addError(tip||'not json format');
-		}
-	}
-	return this;
+  if (this.goOn && !this.hasError()) {
+    try{
+      if('object' == typeof(this.value)) {
+        return this;
+      }
+      this.value = this.params[this.key] = JSON.parse(this.value);
+    }catch(e){
+      this.addError(tip||'not json format');
+    }
+  }
+  return this;
 };
 Validator.prototype.toLowercase = function() {
-	if (this.goOn && !this.hasError()&&this.value) {
-		this.value = this.params[this.key] = this.value.toLowerCase();
-	}
-	return this;
+  if (this.goOn && !this.hasError()&&this.value) {
+    this.value = this.params[this.key] = this.value.toLowerCase();
+  }
+  return this;
 };
 Validator.prototype.toLow = Validator.prototype.toLowercase;
 Validator.prototype.toUppercase = function() {
-	if (this.goOn && !this.hasError()&&this.value) {
-		this.value = this.params[this.key] = this.value.toUpperCase();
-	}
-	return this;
+  if (this.goOn && !this.hasError()&&this.value) {
+    this.value = this.params[this.key] = this.value.toUpperCase();
+  }
+  return this;
 };
 Validator.prototype.toUp = Validator.prototype.toUppercase;
 Validator.prototype.toBoolean = function() {
-	if (this.goOn && !this.hasError()) {
-		if('boolean' == typeof(this.value)) {
-			return this;
-		}
-		if('string' == typeof(this.value)){
-			this.value = this.params[this.key] = v.toBoolean(this.value);
-		}
-	}
-	return this;
+  if (this.goOn && !this.hasError()) {
+    if('boolean' == typeof(this.value)) {
+      return this;
+    }
+    if('string' == typeof(this.value)){
+      this.value = this.params[this.key] = v.toBoolean(this.value);
+    }
+  }
+  return this;
 };
 Validator.prototype.trim = function(c) {
-	if (this.goOn && !this.hasError()) {
-		this.value = this.params[this.key] = v.trim(this.value,c);
-	}
-	return this;
+  if (this.goOn && !this.hasError()) {
+    this.value = this.params[this.key] = v.trim(this.value,c);
+  }
+  return this;
 };
 Validator.prototype.ltrim = function(c) {
-	if (this.goOn && !this.hasError()) {
-		this.value = this.params[this.key] = v.ltrim(this.value,c);
-	}
-	return this;
+  if (this.goOn && !this.hasError()) {
+    this.value = this.params[this.key] = v.ltrim(this.value,c);
+  }
+  return this;
 };
 Validator.prototype.rtrim = function(c) {
-	if (this.goOn && !this.hasError()) {
-		this.value = this.params[this.key] = v.rtrim(this.value,c);
-	}
-	return this;
+  if (this.goOn && !this.hasError()) {
+    this.value = this.params[this.key] = v.rtrim(this.value,c);
+  }
+  return this;
 };
 Validator.prototype.escape = function() {
-	if (this.goOn && !this.hasError()) {
-		this.value = this.params[this.key] = v.escape(this.value);
-	}
-	return this;
+  if (this.goOn && !this.hasError()) {
+    this.value = this.params[this.key] = v.escape(this.value);
+  }
+  return this;
 };
 Validator.prototype.stripLow = function(nl) {
-	if (this.goOn && !this.hasError()) {
-		this.value = this.params[this.key] = v.stripLow(this.value, nl);
-	}
-	return this;
+  if (this.goOn && !this.hasError()) {
+    this.value = this.params[this.key] = v.stripLow(this.value, nl);
+  }
+  return this;
 };
 Validator.prototype.whitelist = function(s) {
-	if (this.goOn && !this.hasError()) {
-		this.value = this.params[this.key] = v.whitelist(this.value,s);
-	}
-	return this;
+  if (this.goOn && !this.hasError()) {
+    this.value = this.params[this.key] = v.whitelist(this.value,s);
+  }
+  return this;
 };
 Validator.prototype.blacklist = function(s) {
-	if (this.goOn && !this.hasError()) {
-		this.value = this.params[this.key] = v.blacklist(this.value,s);
-	}
-	return this;
+  if (this.goOn && !this.hasError()) {
+    this.value = this.params[this.key] = v.blacklist(this.value,s);
+  }
+  return this;
 };
 Validator.prototype.encodeURI = function() {
-	if (this.goOn && !this.hasError()&&this.value) {
-		this.value = this.params[this.key] = encodeURI(this.value);
-	}
-	return this;
+  if (this.goOn && !this.hasError()&&this.value) {
+    this.value = this.params[this.key] = encodeURI(this.value);
+  }
+  return this;
 };
 Validator.prototype.decodeURI = function(tip) {
-	if (this.goOn && !this.hasError()&&this.value) {
-		try{
-			this.value = this.params[this.key] = decodeURI(this.value);
-		}catch(e){
-			this.addError(tip||'bad uri to decode.');
-		}
-	}
-	return this;
+  if (this.goOn && !this.hasError()&&this.value) {
+    try{
+      this.value = this.params[this.key] = decodeURI(this.value);
+    }catch(e){
+      this.addError(tip||'bad uri to decode.');
+    }
+  }
+  return this;
 };
 Validator.prototype.encodeURIComponent = function() {
-	if (this.goOn && !this.hasError()&&this.value) {
-		this.value = this.params[this.key] = encodeURIComponent(this.value);
-	}
-	return this;
+  if (this.goOn && !this.hasError()&&this.value) {
+    this.value = this.params[this.key] = encodeURIComponent(this.value);
+  }
+  return this;
 };
 Validator.prototype.decodeURIComponent = function(tip) {
-	if (this.goOn && !this.hasError()&&this.value) {
-		try{
-			this.value = this.params[this.key] = decodeURIComponent(this.value);
-		}catch(e){
-			this.addError(tip||'bad uri to decode.');
-		}
-	}
-	return this;
+  if (this.goOn && !this.hasError()&&this.value) {
+    try{
+      this.value = this.params[this.key] = decodeURIComponent(this.value);
+    }catch(e){
+      this.addError(tip||'bad uri to decode.');
+    }
+  }
+  return this;
 };
 Validator.prototype.replace = function(a,b) {
-	if (this.goOn && !this.hasError()&&this.value) {
-		this.value = this.params[this.key] = this.value.replace(a,b);
-	}
-	return this;
+  if (this.goOn && !this.hasError()&&this.value) {
+    this.value = this.params[this.key] = this.value.replace(a,b);
+  }
+  return this;
 };
 Validator.prototype.encodeBase64 = function() {
-	if (this.goOn && !this.hasError()&&this.value) {
-		this.value = this.params[this.key] = new Buffer(this.value).toString('base64');
-	}
-	return this;
+  if (this.goOn && !this.hasError()&&this.value) {
+    this.value = this.params[this.key] = new Buffer(this.value).toString('base64');
+  }
+  return this;
 };
 Validator.prototype.decodeBase64 = function(inBuffer ,tip) {
-	if (!this.hasError()&&this.value) {
-		try{
-			if(inBuffer){
-				this.value = this.params[this.key] = new Buffer(this.value , 'base64');
-			}else{
-				this.value = this.params[this.key] = new Buffer(this.value , 'base64').toString();
-			}
-		}catch(e){
-			this.addError(tip||"bad base64 format value");
-		}
-	}
-	return this;
+  if (!this.hasError()&&this.value) {
+    try{
+      if(inBuffer){
+        this.value = this.params[this.key] = new Buffer(this.value , 'base64');
+      }else{
+        this.value = this.params[this.key] = new Buffer(this.value , 'base64').toString();
+      }
+    }catch(e){
+      this.addError(tip||"bad base64 format value");
+    }
+  }
+  return this;
 };
 Validator.prototype.hash = function(alg , enc) {
-	if (!this.hasError()&&this.value) {
-		enc = enc ||'hex';
-		this.value = this.params[this.key] =require('crypto').createHash(alg).update(this.value).digest(enc);
-	}
-	return this;
+  if (!this.hasError()&&this.value) {
+    enc = enc ||'hex';
+    this.value = this.params[this.key] =require('crypto').createHash(alg).update(this.value).digest(enc);
+  }
+  return this;
 };
 Validator.prototype.md5 = function() {
-	this.hash('md5');
-	return this;
+  this.hash('md5');
+  return this;
 };
 Validator.prototype.sha1 = function() {
-	this.hash('sha1');
-	return this;
+  this.hash('sha1');
+  return this;
 };
 Validator.prototype.clone = function(key , value) {
-	if (!this.hasError()&&this.value) {
-		this.value = this.params[key] = ('undefined' == typeof value?this.value:value);
-		this.key = key;
-	}
-	return this;
+  if (!this.hasError()&&this.value) {
+    this.value = this.params[key] = ('undefined' == typeof value?this.value:value);
+    this.key = key;
+  }
+  return this;
 };
 
 
 // for json path value
 
 Validator.prototype.check = function(fn ,tip, scope) {
-	if(this.goOn && !this.hasError()&&!fn.call(scope||this,this.value,this.key,this.context)) {
-		this.addError(tip||this.key+" check failed.")
-	}
-	return this;
+  if(this.goOn && !this.hasError()&&!fn.call(scope||this,this.value,this.key,this.context)) {
+    this.addError(tip||this.key+" check failed.")
+  }
+  return this;
 }
 Validator.prototype.get = function(index) {
-	if (this.value) {
-		this.value = this.value[index||0]
-	}
-	return this;
+  if (this.value) {
+    this.value = this.value[index||0]
+  }
+  return this;
 };
 Validator.prototype.first = function(index) {
-	return this.get(0);
+  return this.get(0);
 };
 Validator.prototype.filter = function(cb,scope) {
-	if (this.value&&this.value.length>0) {
-		var vs = []
-		for(var i = 0 ;i<this.value.length;i++) {
-			if(cb.call(scope||this,this.value[i],i,this.key,this.context)){
-				vs.push(this.value[i])
-			}
-		}
-		this.value=vs;
-	}
-	return this;
+  if (this.value&&this.value.length>0) {
+    var vs = []
+    for(var i = 0 ;i<this.value.length;i++) {
+      if(cb.call(scope||this,this.value[i],i,this.key,this.context)){
+        vs.push(this.value[i])
+      }
+    }
+    this.value=vs;
+  }
+  return this;
 };
 
 Validator.prototype.type = function(t,tip) {
-	if(this.value){
-		if('boolean'==t || 'string'==t|| 'number' == t || 'object' == t || 'undefined' ==t){
-			if(t!=typeof(this.value)) this.addError(tip|| this.key+" is not "+t+"");
-		}else if ('array' == t){
-			if(!util.isArray(this.value)) this.addError(tip|| this.key+" is not array");
-		}else if ('date' == t){
-			if(!util.isDate(this.value)) this.addError(tip|| this.key+" is not date.");
-		}else if ('null' == t){
-			if(!util.isNull(this.value)) this.addError(tip|| this.key+" is not null.");
-		}else if ('nullorundefined' == t.toLowerCase()){
-			if(!util.isNullOrUndefined(this.value)) this.addError(tip|| this.key+" is not primitive type.");
-		}else if ('primitive' == t){
-			if(!util.isPrimitive(this.value)) this.addError(tip|| this.key+" is not primitive type.");
-		}else{
-			console.warn("not support this type check,type:'"+t+"'")
-		}
-	}
-	return this;
+  if(this.value){
+    if('boolean'==t || 'string'==t|| 'number' == t || 'object' == t || 'undefined' ==t){
+      if(t!=typeof(this.value)) this.addError(tip|| this.key+" is not "+t+"");
+    }else if ('array' == t){
+      if(!util.isArray(this.value)) this.addError(tip|| this.key+" is not array");
+    }else if ('date' == t){
+      if(!util.isDate(this.value)) this.addError(tip|| this.key+" is not date.");
+    }else if ('null' == t){
+      if(!util.isNull(this.value)) this.addError(tip|| this.key+" is not null.");
+    }else if ('nullorundefined' == t.toLowerCase()){
+      if(!util.isNullOrUndefined(this.value)) this.addError(tip|| this.key+" is not primitive type.");
+    }else if ('primitive' == t){
+      if(!util.isPrimitive(this.value)) this.addError(tip|| this.key+" is not primitive type.");
+    }else{
+      console.warn("not support this type check,type:'"+t+"'")
+    }
+  }
+  return this;
 };
 
 function coFsExists(file){
-	return function(done){
-		fs.exists(file,function(x){
-			return done(null , x);
-		});
-	};
+  return function(done){
+    fs.exists(file,function(x){
+      return done(null , x);
+    });
+  };
 }
 
 function coFsMd(dir){
-	return function(done){
-		fs.mkdir(dir , done);
-	};
+  return function(done){
+    fs.mkdir(dir , done);
+  };
 }
 
 function coFsIsDir(file){
-	return function(done){
-		fs.stat(file , function(e,r){
-			done(e , r.isDirectory());
-		});
-	};
+  return function(done){
+    fs.stat(file , function(e,r){
+      done(e , r.isDirectory());
+    });
+  };
 }
 
 function coFsCopy(src,dst){
-	return function(done){
-		var srcStream = fs.createReadStream(src);
-		var dstSteam = fs.createWriteStream(dst);
+  return function(done){
+    var srcStream = fs.createReadStream(src);
+    var dstSteam = fs.createWriteStream(dst);
 
-		srcStream.pipe(dstSteam);
-		srcStream.on('end', function() {
-			done();
-		});
-		srcStream.on('error', function(e) {
-			done(e);
-		});
-	};
+    srcStream.pipe(dstSteam);
+    srcStream.on('end', function() {
+      done();
+    });
+    srcStream.on('error', function(e) {
+      done(e);
+    });
+  };
 }
 
 function coFsDel(file){
-	return function(done){
-		fs.unlink(file ,done);
-	};
+  return function(done){
+    fs.unlink(file ,done);
+  };
 }
 
 function*ensureDir(dir){
-	if(!(yield coFsExists(dir))){
-		yield ensureDir(path.dirname(dir));
-		yield coFsMd(dir);
-	}
+  if(!(yield coFsExists(dir))){
+    yield ensureDir(path.dirname(dir));
+    yield coFsMd(dir);
+  }
 }
 
 function delFileAsync(path ,cb){
-	if(!path){
-		if(cb)cb();
-		return;
-	}
-	fs.unlink(path , function(e){
-		if(e){
-			console.error(e);
-		}
-		if(cb)cb(e);
-	});
+  if(!path){
+    if(cb)cb();
+    return;
+  }
+  fs.unlink(path , function(e){
+    if(e){
+      console.error(e);
+    }
+    if(cb)cb(e);
+  });
 }
 
 function isGeneratorFunction(obj) {
@@ -807,130 +802,130 @@ function isGeneratorFunction(obj) {
 }
 
 function formatSize(size){
-	if(size<1024){
-		return size+" bytes";
-	}else if(size>=1024 && size<1024*1024){
-		return (size/1024).toFixed(2)+" kb";
-	}else if(size >= 1024*1024 && size<1024*1024*1024){
-		return (size/(1024*1024)).toFixed(2)+" mb";
-	}else{
-		return (size/(1024*1024*1024)).toFixed(2)+" gb";
-	}
+  if(size<1024){
+    return size+" bytes";
+  }else if(size>=1024 && size<1024*1024){
+    return (size/1024).toFixed(2)+" kb";
+  }else if(size >= 1024*1024 && size<1024*1024*1024){
+    return (size/(1024*1024)).toFixed(2)+" mb";
+  }else{
+    return (size/(1024*1024*1024)).toFixed(2)+" gb";
+  }
 }
 
 /**
 use koa-body ,file object will be {type:"image/jpeg",path:"",name:"",size:"",mtile:""}
 */
 function FileValidator(context, key, value, exists, params,deleteOnCheckFailed){
-	Validator.call(this,context, key, value, exists, params ,true);
-	this.deleteOnCheckFailed = deleteOnCheckFailed;
+  Validator.call(this,context, key, value, exists, params ,true);
+  this.deleteOnCheckFailed = deleteOnCheckFailed;
 }
 require("util").inherits(FileValidator, Validator);
 module.exports.FileValidator = FileValidator;
 
 
 FileValidator.prototype.notEmpty = function(tip){
-	if (this.goOn && (!this.value||this.value.size<=0)) {
-		this.addError(tip || "file "+ this.key + " can not be a empty file.");
-		if(this.deleteOnCheckFailed){
-			delFileAsync(this.value&&this.value.path);
-		}
-	}
-	return this;
+  if (this.goOn && (!this.value||this.value.size<=0)) {
+    this.addError(tip || "file "+ this.key + " can not be a empty file.");
+    if(this.deleteOnCheckFailed){
+      delFileAsync(this.value&&this.value.path);
+    }
+  }
+  return this;
 };
 
 FileValidator.prototype.size = function(min,max,tip){
-	if (this.goOn && (!this.value||this.value.size<min || this.value.size>max)) {
-		this.addError(tip || "file "+(this.value && this.value.name||this.key) + "' length must between "+formatSize(min)+" and "+formatSize(max)+".");
-		if(this.deleteOnCheckFailed){
-			delFileAsync(this.value &&this.value.path);
-		}
-	}
-	return this;
+  if (this.goOn && (!this.value||this.value.size<min || this.value.size>max)) {
+    this.addError(tip || "file "+(this.value && this.value.name||this.key) + "' length must between "+formatSize(min)+" and "+formatSize(max)+".");
+    if(this.deleteOnCheckFailed){
+      delFileAsync(this.value &&this.value.path);
+    }
+  }
+  return this;
 };
 FileValidator.prototype.contentTypeMatch = function(reg,tip){
-	if (this.goOn && (!this.value || !reg.test(this.value.type))) {
-		this.addError(tip || "file "+ (this.value && this.value.name||this.key) + " is bad format.");
-		if(this.deleteOnCheckFailed){
-			delFileAsync(this.value &&this.value.path);
-		}
-	}
-	return this;
+  if (this.goOn && (!this.value || !reg.test(this.value.type))) {
+    this.addError(tip || "file "+ (this.value && this.value.name||this.key) + " is bad format.");
+    if(this.deleteOnCheckFailed){
+      delFileAsync(this.value &&this.value.path);
+    }
+  }
+  return this;
 };
 FileValidator.prototype.isImageContentType = function(tip){
-	if (this.goOn && (!this.value || 0!==this.value.type.indexOf('image/'))) {
-		this.addError(tip || "file "+ (this.value && this.value.name||this.key) + " is not a image format.");
-		if(this.deleteOnCheckFailed){
-			delFileAsync(this.value &&this.value.path);
-		}
-	}
-	return this;
+  if (this.goOn && (!this.value || 0!==this.value.type.indexOf('image/'))) {
+    this.addError(tip || "file "+ (this.value && this.value.name||this.key) + " is not a image format.");
+    if(this.deleteOnCheckFailed){
+      delFileAsync(this.value &&this.value.path);
+    }
+  }
+  return this;
 };
 FileValidator.prototype.fileNameMatch = function(reg,tip){
-	if (this.goOn && (!this.value || !reg.test(this.value.name))) {
-		this.addError(tip || "file "+ (this.value && this.value.name||this.key) + " is bad file type.");
-		if(this.deleteOnCheckFailed){
-			delFileAsync(this.value&&this.value.path);
-		}
-	}
-	return this;
+  if (this.goOn && (!this.value || !reg.test(this.value.name))) {
+    this.addError(tip || "file "+ (this.value && this.value.name||this.key) + " is bad file type.");
+    if(this.deleteOnCheckFailed){
+      delFileAsync(this.value&&this.value.path);
+    }
+  }
+  return this;
 };
 FileValidator.prototype.suffixIn = function(arr,tip){
-	if (this.goOn && (!this.value || -1==arr.indexOf(-1==this.value.name.lastIndexOf('.')?"":this.value.name.substring(this.value.name.lastIndexOf('.')+1)))) {
-		this.addError(tip || "file "+ (this.value && this.value.name||this.key) + " is bad file type.");
-		if(this.deleteOnCheckFailed){
-			delFileAsync(this.value &&this.value.path);
-		}
-	}
-	return this;
+  if (this.goOn && (!this.value || -1==arr.indexOf(-1==this.value.name.lastIndexOf('.')?"":this.value.name.substring(this.value.name.lastIndexOf('.')+1)))) {
+    this.addError(tip || "file "+ (this.value && this.value.name||this.key) + " is bad file type.");
+    if(this.deleteOnCheckFailed){
+      delFileAsync(this.value &&this.value.path);
+    }
+  }
+  return this;
 };
 FileValidator.prototype.move = function*(dst,afterMove){
-	if (this.goOn && this.value ) {
-		yield this.copy(dst);
-		yield coFsDel(this.value.path);
-		if('function' == typeof afterMove){
-			if(isGeneratorFunction(afterMove)){
-				yield afterMove(this.value,this.key,this.context);
-			}else{
-				afterMove(this.value,this.key,this.context);
-			}
-		}
-	}
-	return this;
+  if (this.goOn && this.value ) {
+    yield this.copy(dst);
+    yield coFsDel(this.value.path);
+    if('function' == typeof afterMove){
+      if(isGeneratorFunction(afterMove)){
+        yield afterMove(this.value,this.key,this.context);
+      }else{
+        afterMove(this.value,this.key,this.context);
+      }
+    }
+  }
+  return this;
 };
 FileValidator.prototype.copy = function*(dst,afterCopy){
-	if (this.goOn && this.value ) {
-		var dstFile = dst;
-		if('function' == typeof dst){
-			if(isGeneratorFunction(dst)){
-				dstFile = yield dst(this.value,this.key,this.context);
-			}else{
-				dstFile = dst(this.value,this.key,this.context);
-			}
-		}
-		if(!(yield coFsExists(this.value.path))){
-			this.addError('upload file not exists');
-			return;
-		}
-		if(dstFile.length-1 == dstFile.lastIndexOf('/') ||dstFile.length-1 == dstFile.lastIndexOf('\\')||(yield coFsExists(dstFile)) && (yield coFsIsDir(dstFile))){
-			dstFile = path.join(dstFile , path.basename(this.value.path));
-		}
-		yield ensureDir(path.dirname(dstFile));
-		yield coFsCopy(this.value.path,dstFile);
-		this.value.newPath = dstFile;
-		if('function' == typeof afterCopy){
-			if(isGeneratorFunction(afterCopy)){
-				yield afterCopy(this.value,this.key,this.context);
-			}else{
-				afterCopy(this.value,this.key,this.context);
-			}
-		}
-	}
-	return this;
+  if (this.goOn && this.value ) {
+    var dstFile = dst;
+    if('function' == typeof dst){
+      if(isGeneratorFunction(dst)){
+        dstFile = yield dst(this.value,this.key,this.context);
+      }else{
+        dstFile = dst(this.value,this.key,this.context);
+      }
+    }
+    if(!(yield coFsExists(this.value.path))){
+      this.addError('upload file not exists');
+      return;
+    }
+    if(dstFile.length-1 == dstFile.lastIndexOf('/') ||dstFile.length-1 == dstFile.lastIndexOf('\\')||(yield coFsExists(dstFile)) && (yield coFsIsDir(dstFile))){
+      dstFile = path.join(dstFile , path.basename(this.value.path));
+    }
+    yield ensureDir(path.dirname(dstFile));
+    yield coFsCopy(this.value.path,dstFile);
+    this.value.newPath = dstFile;
+    if('function' == typeof afterCopy){
+      if(isGeneratorFunction(afterCopy)){
+        yield afterCopy(this.value,this.key,this.context);
+      }else{
+        afterCopy(this.value,this.key,this.context);
+      }
+    }
+  }
+  return this;
 };
 FileValidator.prototype.delete = function*(){
-	if (this.goOn && this.value ) {
-		yield coFsDel(this.value.path);
-	}
-	return this;
+  if (this.goOn && this.value ) {
+    yield coFsDel(this.value.path);
+  }
+  return this;
 };

--- a/validate.js
+++ b/validate.js
@@ -27,7 +27,7 @@ const hasKey = (obj, key, transFn) => {
       resultType: 'all'
     });
     if (!Array.isArray(result)) result = [result];
-    return result.length > 0;
+    return result.length === 1 && result[0] !== undefined;
   }
   return key in obj;
 }

--- a/validate.js
+++ b/validate.js
@@ -219,13 +219,14 @@ Validator.prototype.in = function(arr, tip) {
 Validator.prototype.isIn = Validator.prototype.in;
 Validator.prototype.eq = function(l, tip) {
 	if (this.goOn && this.value != l) {
-		this.addError(tip || this.key + " is must equal " + l + ".");
+		this.addError(tip || this.key + " must equal " + l + ".");
 	}
 	return this;
 };
 Validator.prototype.neq = function(l, tip) {
 	if (this.goOn && this.value == l) {
-		this.addError(tip || this.key + " is must not equal " + l + ".");
+		console.log('adding the error!')
+		this.addError(tip || this.key + " must not equal " + l + ".");
 	}
 	return this;
 };
@@ -255,13 +256,13 @@ Validator.prototype.le = function(l, tip) {
 };
 Validator.prototype.contains = function(s, tip) {
 	if (this.goOn && (!isString(this.value) ||!v.contains(this.value,s))) {
-		this.addError(tip || this.key + " is must contain " + s + ".");
+		this.addError(tip || this.key + " must contain " + s + ".");
 	}
 	return this;
 };
 Validator.prototype.notContains = function(s, tip) {
 	if (this.goOn && (!isString(this.value) ||v.contains(this.value,s))) {
-		this.addError(tip || this.key + " is must not contain " + s + ".");
+		this.addError(tip || this.key + " must not contain " + s + ".");
 	}
 	return this;
 };

--- a/validate.js
+++ b/validate.js
@@ -339,9 +339,9 @@ Validator.prototype.isDivisibleBy = function(n, tip) {
 	}
 	return this;
 };
-Validator.prototype.isNull = function(tip) {
-	if (this.goOn && (!isString(this.value) ||!v.isNull(this.value))) {
-		this.addError(tip || this.key + " is not null.");
+Validator.prototype.isEmpty = function(tip) {
+	if (this.goOn && (!isString(this.value) ||!v.isEmpty(this.value))) {
+		this.addError(tip || this.key + " is not empty.");
 	}
 	return this;
 };


### PR DESCRIPTION
There are a couple of breaking changes in here to point out which became necessary.

1. the entire "json path" functionality was actually xpath -- it is now jsonpath.  The original author of json-path wrote an article comparing xpath to json path and extolling the virtues of the latter, but the underlying library was using xpath and all unit tests that said jsonpath actually had xpath in the inputs. This was confusing as hell to unwind as I could not figure out why this was the case.  
The replacement library for json-path, jsonpath-plus even references the old jsonpath library, but it no longer supports xpath and I couldn't find a good way to support xpath for json traversal nor really a good reason to.
2. The latest version of validate (which became validator.js) was 8 major versions ahead, but the only breaking change was on the usage if `isNull`.  It was deprecated and then dropped, because it only checked strings and only handled emptiness. It was replaced with `isEmpty`. Since original _intent_ was for the same isEmpty usage (the unit tests in this library only tested two strings against that function, one empty + one not), I preferred to change the function to `isEmpty` rather than making a functional version of `isNull`. 

On the 1st issue, we are probably fine. I don't think we ever used this in our code, but its a pretty powerful tool if we want to.  On the 2nd issue, I'm guessing we need to double check for usage here. 