### PR TITLE
Fix security issue jsonpath plus

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "jsonpath-plus": "^7.2.0",
+    "jsonpath-plus": "^10.1.0",
     "validator": "^13.9.0"
   },
   "devDependencies": {

--- a/validate.js
+++ b/validate.js
@@ -640,8 +640,8 @@ Validator.prototype.replace = function(a,b) {
   return this;
 };
 Validator.prototype.encodeBase64 = function() {
-  if (this.goOn && !this.hasError()&&this.value) {
-    this.value = this.params[this.key] = new Buffer(this.value).toString('base64');
+  if (this.goOn && !this.hasError() && this.value) {
+    this.value = this.params[this.key] = Buffer.from(this.value).toString('base64');
   }
   return this;
 };
@@ -649,9 +649,9 @@ Validator.prototype.decodeBase64 = function(inBuffer ,tip) {
   if (!this.hasError()&&this.value) {
     try{
       if(inBuffer){
-        this.value = this.params[this.key] = new Buffer(this.value , 'base64');
+        this.value = this.params[this.key] = Buffer.from(this.value, 'base64');
       }else{
-        this.value = this.params[this.key] = new Buffer(this.value , 'base64').toString();
+        this.value = this.params[this.key] = new Buffer.from(this.value , 'base64').toString();
       }
     }catch(e){
       this.addError(tip||"bad base64 format value");


### PR DESCRIPTION
Upgraded jsonpath-plus to 10.1.0, which is the latest.
When running `yarn test` a deprecation error popped up saying Buffer() is deprecated. I followed the suggestions to use Buffer.from() instead.